### PR TITLE
Filters should accept an options array

### DIFF
--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -11,13 +11,39 @@ use Laminas\I18n\PhoneNumber\PhoneNumberValue;
 use Stringable;
 
 use function is_scalar;
+use function is_string;
 
-/** @internal Laminas\i18n  */
+/**
+ * @internal Laminas\i18n
+ *
+ * @psalm-type Options = array{country-code: non-empty-string}
+ */
 abstract class AbstractFilter implements FilterInterface
 {
+    /** @param Options|null $options */
     final public function __construct(
-        private readonly CountryCode $countryCode
+        private CountryCode $countryCode,
+        array|null $options = null,
     ) {
+        if ($options === null) {
+            return;
+        }
+
+        $this->setOptions($options);
+    }
+
+    /** @param non-empty-string|CountryCode $code */
+    final public function setCountryCode(string|CountryCode $code): void
+    {
+        $this->countryCode = is_string($code) ? CountryCode::fromString($code) : $code;
+    }
+
+    /** @param array<string, mixed> $options */
+    final public function setOptions(array $options): void
+    {
+        if (isset($options['country-code']) && is_string($options['country-code']) && $options['country-code'] !== '') {
+            $this->setCountryCode($options['country-code']);
+        }
     }
 
     final protected function tryMixedToPhoneNumber(mixed $value): ?PhoneNumberValue

--- a/src/Filter/Factory/ToE164Factory.php
+++ b/src/Filter/Factory/ToE164Factory.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Laminas\I18n\PhoneNumber\Filter\Factory;
 
 use Laminas\I18n\PhoneNumber\Factory\Configuration;
+use Laminas\I18n\PhoneNumber\Filter\AbstractFilter;
 use Laminas\I18n\PhoneNumber\Filter\ToE164;
 use Psr\Container\ContainerInterface;
 
+/** @psalm-import-type Options from AbstractFilter */
 final class ToE164Factory
 {
-    public function __invoke(ContainerInterface $container): ToE164
-    {
-        return new ToE164(Configuration::defaultCountryCode($container));
+    /** @param Options|null $options */
+    public function __invoke(
+        ContainerInterface $container,
+        string|null $name = null,
+        array|null $options = null,
+    ): ToE164 {
+        return new ToE164(Configuration::defaultCountryCode($container), $options);
     }
 }

--- a/src/Filter/Factory/ToInternationalPhoneNumberFactory.php
+++ b/src/Filter/Factory/ToInternationalPhoneNumberFactory.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Laminas\I18n\PhoneNumber\Filter\Factory;
 
 use Laminas\I18n\PhoneNumber\Factory\Configuration;
+use Laminas\I18n\PhoneNumber\Filter\AbstractFilter;
 use Laminas\I18n\PhoneNumber\Filter\ToInternationalPhoneNumber;
 use Psr\Container\ContainerInterface;
 
+/** @psalm-import-type Options from AbstractFilter */
 final class ToInternationalPhoneNumberFactory
 {
-    public function __invoke(ContainerInterface $container): ToInternationalPhoneNumber
-    {
-        return new ToInternationalPhoneNumber(Configuration::defaultCountryCode($container));
+    /** @param Options|null $options */
+    public function __invoke(
+        ContainerInterface $container,
+        string|null $name = null,
+        array|null $options = null,
+    ): ToInternationalPhoneNumber {
+        return new ToInternationalPhoneNumber(Configuration::defaultCountryCode($container), $options);
     }
 }

--- a/src/Filter/Factory/ToNationalPhoneNumberFactory.php
+++ b/src/Filter/Factory/ToNationalPhoneNumberFactory.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Laminas\I18n\PhoneNumber\Filter\Factory;
 
 use Laminas\I18n\PhoneNumber\Factory\Configuration;
+use Laminas\I18n\PhoneNumber\Filter\AbstractFilter;
 use Laminas\I18n\PhoneNumber\Filter\ToNationalPhoneNumber;
 use Psr\Container\ContainerInterface;
 
+/** @psalm-import-type Options from AbstractFilter */
 final class ToNationalPhoneNumberFactory
 {
-    public function __invoke(ContainerInterface $container): ToNationalPhoneNumber
-    {
-        return new ToNationalPhoneNumber(Configuration::defaultCountryCode($container));
+    /** @param Options|null $options */
+    public function __invoke(
+        ContainerInterface $container,
+        string|null $name = null,
+        array|null $options = null,
+    ): ToNationalPhoneNumber {
+        return new ToNationalPhoneNumber(Configuration::defaultCountryCode($container), $options);
     }
 }

--- a/test/Filter/AbstractFilterTest.php
+++ b/test/Filter/AbstractFilterTest.php
@@ -93,4 +93,39 @@ class AbstractFilterTest extends TestCase
         $filtered = $filter->filter($object);
         self::assertIsString($filtered);
     }
+
+    /**
+     * @dataProvider filterClassProvider
+     * @param class-string<AbstractFilter> $class
+     */
+    public function testThatTheDefaultCountryCodeCanBeOverriddenBySettingOptionsAtRuntime(string $class): void
+    {
+        $filter = new $class(CountryCode::fromString('GB'));
+        $filter->setOptions(['country-code' => 'DE']);
+        $value = $filter->filter('(0)30-23125 000');
+        self::assertIsString($value);
+        $expect = [
+            'international' => '+49 30 23125000',
+            'E164'          => '+493023125000',
+            'national'      => '030 23125000',
+        ];
+        self::assertContains($value, $expect);
+    }
+
+    /**
+     * @dataProvider filterClassProvider
+     * @param class-string<AbstractFilter> $class
+     */
+    public function testThatTheDefaultCountryCodeCanBeOverriddenBySettingOptionsDuringConstruction(string $class): void
+    {
+        $filter = new $class(CountryCode::fromString('GB'), ['country-code' => 'DE']);
+        $value  = $filter->filter('(0)30-23125 000');
+        self::assertIsString($value);
+        $expect = [
+            'international' => '+49 30 23125000',
+            'E164'          => '+493023125000',
+            'national'      => '030 23125000',
+        ];
+        self::assertContains($value, $expect);
+    }
 }

--- a/test/Filter/FilterPluginManagerIntegrationTest.php
+++ b/test/Filter/FilterPluginManagerIntegrationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\PhoneNumber\Test\Filter;
+
+use Laminas\Filter\FilterPluginManager;
+use Laminas\I18n\PhoneNumber\ConfigProvider;
+use Laminas\I18n\PhoneNumber\Filter\AbstractFilter;
+use Laminas\I18n\PhoneNumber\Filter\ToE164;
+use Laminas\I18n\PhoneNumber\Filter\ToInternationalPhoneNumber;
+use Laminas\I18n\PhoneNumber\Filter\ToNationalPhoneNumber;
+use Laminas\ServiceManager\ServiceManager;
+use PHPUnit\Framework\TestCase;
+
+final class FilterPluginManagerIntegrationTest extends TestCase
+{
+    private FilterPluginManager $pluginManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->pluginManager = new FilterPluginManager(new ServiceManager());
+        $config              = (new ConfigProvider())->__invoke()['filters'];
+        $this->pluginManager->configure($config);
+    }
+
+    /** @return array<string, array{0: class-string<AbstractFilter>, 1: string}> */
+    public function filterClassProvider(): array
+    {
+        return [
+            'E164'          => [ToE164::class, 'toE164'],
+            'International' => [ToInternationalPhoneNumber::class, 'toInternationalPhoneNumber'],
+            'National'      => [ToNationalPhoneNumber::class, 'toNationalPhoneNumber'],
+        ];
+    }
+
+    /**
+     * @dataProvider filterClassProvider
+     * @param class-string<AbstractFilter> $expectedClassName
+     */
+    public function testFiltersCanBeRetrievedByAlias(string $expectedClassName, string $alias): void
+    {
+        self::assertInstanceOf(
+            $expectedClassName,
+            $this->pluginManager->get($alias),
+        );
+    }
+
+    /**
+     * @dataProvider filterClassProvider
+     * @param class-string<AbstractFilter> $expectedClassName
+     */
+    public function testFiltersCanBeRetrievedByClassName(string $expectedClassName): void
+    {
+        self::assertInstanceOf(
+            $expectedClassName,
+            $this->pluginManager->get($expectedClassName),
+        );
+    }
+
+    public function testThatFiltersAreNotSharedByDefault(): void
+    {
+        self::assertNotSame(
+            $this->pluginManager->get(ToE164::class),
+            $this->pluginManager->get(ToE164::class),
+        );
+    }
+
+    public function testThatFiltersWillAcceptOptionsToCustomiseTheCountryCode(): void
+    {
+        $de = $this->pluginManager->get(ToE164::class, ['country-code' => 'DE']);
+        $au = $this->pluginManager->get(ToE164::class, ['country-code' => 'AU']);
+
+        self::assertSame('+493023125000', $de->filter('(0)30-23125 000'));
+        self::assertSame('+61255501234', $au->filter('(02) 5550 1234'));
+    }
+}


### PR DESCRIPTION
Filters should accept an options array so that they can be customised per input when used with `laminas-form`

Closes #8 