### PR TITLE
Validator country context

### DIFF
--- a/src/Validator/Factory/PhoneNumberFactory.php
+++ b/src/Validator/Factory/PhoneNumberFactory.php
@@ -19,7 +19,7 @@ final class PhoneNumberFactory
     public function __invoke(
         ContainerInterface $container,
         ?string $requestedName = null,
-        array $options = []
+        ?array $options = null
     ): PhoneNumber {
         $componentOptions = Configuration::componentConfig($container);
 
@@ -27,7 +27,7 @@ final class PhoneNumberFactory
         $resolvedOptions = array_merge([
             'country'       => $componentOptions['default-country-code'] ?? null,
             'allowed_types' => $componentOptions['acceptable-number-types'] ?? null,
-        ], $options);
+        ], $options ?? []);
 
         return new PhoneNumber($resolvedOptions);
     }

--- a/src/Validator/PhoneNumber.php
+++ b/src/Validator/PhoneNumber.php
@@ -14,7 +14,7 @@ use Laminas\Validator\AbstractValidator;
 use Stringable;
 use Traversable;
 
-use function assert;
+use function is_array;
 use function is_int;
 use function is_scalar;
 use function is_string;
@@ -63,15 +63,21 @@ final class PhoneNumber extends AbstractValidator
             $options = ArrayUtils::iteratorToArray($options);
         }
 
-        if (isset($options['country'])) {
-            assert(is_string($options['country']) && $options['country'] !== '');
+        if (! is_array($options)) {
+            parent::__construct();
+
+            return;
+        }
+
+        if (isset($options['country']) && is_string($options['country']) && $options['country'] !== '') {
             $this->setCountry($options['country']);
         }
 
-        if (isset($options['allowed_types'])) {
-            assert(is_int($options['allowed_types']));
+        if (isset($options['allowed_types']) && is_int($options['allowed_types'])) {
             $this->setAllowedTypes($options['allowed_types']);
         }
+
+        unset($options['country'], $options['allowed_types']);
 
         parent::__construct($options);
     }

--- a/src/Validator/PhoneNumber.php
+++ b/src/Validator/PhoneNumber.php
@@ -22,8 +22,9 @@ use function sprintf;
 
 /**
  * @psalm-type Options = array{
- *     country?: non-empty-string,
- *     allowed_types?: int,
+ *     country?: non-empty-string|null,
+ *     country_context?: non-empty-string|null,
+ *     allowed_types?: int|null,
  * }
  */
 final class PhoneNumber extends AbstractValidator
@@ -56,6 +57,17 @@ final class PhoneNumber extends AbstractValidator
      */
     private int $allowTypes = PhoneNumberValue::TYPE_ANY;
 
+    /**
+     * Input name to check for an ISO 3166 Country Code during validation
+     *
+     * If non-empty, the validation context will be searched for the value corresponding to the given key. When found,
+     * and when the value is a valid country code, the given phone number will be validated as a number for the country
+     * determined by this value.
+     *
+     * @var non-empty-string|null
+     */
+    private ?string $countryContext = null;
+
     /** @param Options|Traversable<string, mixed>|null $options */
     public function __construct($options = null)
     {
@@ -73,6 +85,14 @@ final class PhoneNumber extends AbstractValidator
             $this->setCountry($options['country']);
         }
 
+        if (
+            isset($options['country_context'])
+            && is_string($options['country_context'])
+            && $options['country_context'] !== ''
+        ) {
+            $this->setCountryContext($options['country_context']);
+        }
+
         if (isset($options['allowed_types']) && is_int($options['allowed_types'])) {
             $this->setAllowedTypes($options['allowed_types']);
         }
@@ -82,8 +102,11 @@ final class PhoneNumber extends AbstractValidator
         parent::__construct($options);
     }
 
-    /** @param mixed $value */
-    public function isValid($value): bool
+    /**
+     * @param mixed $value
+     * @param array<string, mixed> $context
+     */
+    public function isValid($value, ?array $context = null): bool
     {
         if (! is_scalar($value) && ! $value instanceof Stringable) {
             $this->error(self::INVALID_TYPE);
@@ -101,8 +124,10 @@ final class PhoneNumber extends AbstractValidator
             return false;
         }
 
+        $country = $this->resolveCountry($context);
+
         try {
-            $number = PhoneNumberValue::fromString($value, $this->country?->toString());
+            $number = PhoneNumberValue::fromString($value, $country?->toString());
         } catch (UnrecognizableNumberException) {
             $this->error(self::NO_MATCH);
 
@@ -138,6 +163,12 @@ final class PhoneNumber extends AbstractValidator
         $this->country = $code;
     }
 
+    /** @param non-empty-string $inputName */
+    public function setCountryContext(string $inputName): void
+    {
+        $this->countryContext = $inputName;
+    }
+
     public function setAllowedTypes(int $types): void
     {
         if ($types <= 0 || ($types & PhoneNumberValue::TYPE_KNOWN) !== $types) {
@@ -145,5 +176,20 @@ final class PhoneNumber extends AbstractValidator
         }
 
         $this->allowTypes = $types;
+    }
+
+    /** @param array<string, mixed> $validationContext */
+    private function resolveCountry(?array $validationContext): ?CountryCode
+    {
+        if (! is_array($validationContext) || ! $this->countryContext) {
+            return $this->country;
+        }
+
+        $code = $validationContext[$this->countryContext] ?? null;
+        if (! is_string($code) || $code === '') {
+            return $this->country;
+        }
+
+        return CountryCode::tryFromString($code) ?? $this->country;
     }
 }

--- a/test/Validator/Factory/PhoneNumberFactoryTest.php
+++ b/test/Validator/Factory/PhoneNumberFactoryTest.php
@@ -54,4 +54,10 @@ class PhoneNumberFactoryTest extends TestCase
         self::assertFalse($validator->isValid('+4401234567890'));
         self::assertTrue($validator->isValid('999'));
     }
+
+    public function testThatValidatorOptionsCanBeNull(): void
+    {
+        ($this->factory)($this->container);
+        self::assertTrue(true);
+    }
 }

--- a/test/Validator/PhoneNumberTest.php
+++ b/test/Validator/PhoneNumberTest.php
@@ -205,4 +205,19 @@ class PhoneNumberTest extends TestCase
         self::assertArrayHasKey(PhoneNumber::INVALID, $messages);
         self::assertCount(1, $messages);
     }
+
+    public function testOptionsCanHaveNullValues(): void
+    {
+        new PhoneNumber([
+            'country'       => null,
+            'allowed_types' => null,
+        ]);
+        self::assertTrue(true);
+    }
+
+    public function testOptionsCanBeNull(): void
+    {
+        new PhoneNumber(null);
+        self::assertTrue(true);
+    }
 }

--- a/test/Validator/PhoneNumberTest.php
+++ b/test/Validator/PhoneNumberTest.php
@@ -206,11 +206,12 @@ class PhoneNumberTest extends TestCase
         self::assertCount(1, $messages);
     }
 
-    public function testOptionsCanHaveNullValues(): void
+    public function testAllOptionsCanHaveNullValues(): void
     {
         new PhoneNumber([
-            'country'       => null,
-            'allowed_types' => null,
+            'country'         => null,
+            'allowed_types'   => null,
+            'country_context' => null,
         ]);
         self::assertTrue(true);
     }
@@ -219,5 +220,22 @@ class PhoneNumberTest extends TestCase
     {
         new PhoneNumber(null);
         self::assertTrue(true);
+    }
+
+    public function testThatCountryContextIsConsidered(): void
+    {
+        $input   = '01234 567 890';
+        $context = [
+            'number'   => $input,
+            'my-field' => 'GB',
+        ];
+
+        $validator = new PhoneNumber();
+        self::assertFalse($validator->isValid($input, $context));
+
+        $validator = new PhoneNumber([
+            'country_context' => 'my-field',
+        ]);
+        self::assertTrue($validator->isValid($input, $context));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| New Feature   | yes

### Description

Closes #7 

So that the validator is more useful in forms, country context can be used to validate a given number against a country code value that is part of the same form.

Also fixes the validator factory and the validator itself to be more lenient with options and possible nulls. Typically, FormElementManager and ValidatorPluginManager may well pass null to options parameters