### PR TITLE
Introduce a PhoneNumber Form Element for use with Laminas Form

### DIFF
--- a/.psr-container.php.stub
+++ b/.psr-container.php.stub
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psr\Container {
+    /**
+     * Provides automatic type inference for Psalm when retrieving a service from a container using a FQCN
+     */
+    interface ContainerInterface
+    {
+        /**
+         * @param string|class-string $id
+         */
+        public function has(string $id): bool;
+
+        /**
+         * @template T
+         * @psalm-param string|class-string<T> $id
+         * @psalm-return ($id is class-string ? T : mixed)
+         */
+        public function get(string $id);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.4.0",
+        "laminas/laminas-config-aggregator": "^1.11",
         "laminas/laminas-servicemanager": "^3.19",
         "phpunit/phpunit": "^9.5.26",
         "psalm/plugin-phpunit": "^0.18.3",

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,9 @@
         "ext-intl": "*",
         "giggsey/libphonenumber-for-php": "^8.13",
         "laminas/laminas-filter": "^2.27",
+        "laminas/laminas-form": "^3.5",
         "laminas/laminas-i18n": "^2.19",
+        "laminas/laminas-inputfilter": "^2.22",
         "laminas/laminas-stdlib": "^3.15",
         "laminas/laminas-validator": "^2.26"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "16b299127cee2bda2bc159c31b07f887",
+    "content-hash": "3fadd0bcca6270fd33619dbf8e14d23c",
     "packages": [
         {
             "name": "giggsey/libphonenumber-for-php",
@@ -1136,6 +1136,55 @@
             "time": "2021-03-30T17:13:30+00:00"
         },
         {
+            "name": "brick/varexporter",
+            "version": "0.3.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "3e263cd718d242594c52963760fee2059fd5833c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/3e263cd718d242594c52963760fee2059fd5833c",
+                "reference": "3e263cd718d242594c52963760fee2059fd5833c",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "vimeo/psalm": "4.23.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.3.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-06-29T23:37:57+00:00"
+        },
+        {
             "name": "composer/package-versions-deprecated",
             "version": "1.11.99.5",
             "source": {
@@ -1764,6 +1813,75 @@
                 }
             ],
             "time": "2022-08-24T17:45:47+00:00"
+        },
+        {
+            "name": "laminas/laminas-config-aggregator",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-config-aggregator.git",
+                "reference": "847394b3435081e93464341261446e453051d1af"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-config-aggregator/zipball/847394b3435081e93464341261446e453051d1af",
+                "reference": "847394b3435081e93464341261446e453051d1af",
+                "shasum": ""
+            },
+            "require": {
+                "brick/varexporter": "^0.3.7",
+                "laminas/laminas-stdlib": "^3.10.1",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "webimpress/safe-writer": "^2.2.0"
+            },
+            "conflict": {
+                "nikic/php-parser": "<4.12",
+                "zendframework/zend-config-aggregator": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-config": "^3.7.0",
+                "laminas/laminas-servicemanager": "^3.19",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.29"
+            },
+            "suggest": {
+                "laminas/laminas-config": "Allows loading configuration from XML, INI, YAML, and JSON files",
+                "laminas/laminas-config-aggregator-modulemanager": "Allows loading configuration from laminas-mvc Module classes",
+                "laminas/laminas-config-aggregator-parameters": "Allows usage of templated parameters within your configuration"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ConfigAggregator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Lightweight library for collecting and merging configuration from different sources",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "config-aggregator",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-config-aggregator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-config-aggregator/issues",
+                "rss": "https://github.com/laminas/laminas-config-aggregator/releases.atom",
+                "source": "https://github.com/laminas/laminas-config-aggregator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-10-11T23:40:37+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4788,6 +4906,65 @@
                 }
             ],
             "time": "2022-02-15T19:52:12+00:00"
+        },
+        {
+            "name": "webimpress/safe-writer",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/safe-writer.git",
+                "reference": "9d37cc8bee20f7cb2f58f6e23e05097eab5072e6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/safe-writer/zipball/9d37cc8bee20f7cb2f58f6e23e05097eab5072e6",
+                "reference": "9d37cc8bee20f7cb2f58f6e23e05097eab5072e6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4",
+                "vimeo/psalm": "^4.7",
+                "webimpress/coding-standard": "^1.2.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.2.x-dev",
+                    "dev-develop": "2.3.x-dev",
+                    "dev-release-1.0": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webimpress\\SafeWriter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Tool to write files safely, to avoid race conditions",
+            "keywords": [
+                "concurrent write",
+                "file writer",
+                "race condition",
+                "safe writer",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/safe-writer/issues",
+                "source": "https://github.com/webimpress/safe-writer/tree/2.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-19T16:34:45+00:00"
         },
         {
             "name": "webmozart/path-util",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0147ebe091a78b2b37c8d1801e71358e",
+    "content-hash": "16b299127cee2bda2bc159c31b07f887",
     "packages": [
         {
             "name": "giggsey/libphonenumber-for-php",
@@ -134,16 +134,16 @@
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.27.0",
+            "version": "2.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "c038ae257028b57b1f96df0d4ccb68cfc04eaa40"
+                "reference": "b0290636e88083acb42dba7b883aeaa16a60244f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/c038ae257028b57b1f96df0d4ccb68cfc04eaa40",
-                "reference": "c038ae257028b57b1f96df0d4ccb68cfc04eaa40",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/b0290636e88083acb42dba7b883aeaa16a60244f",
+                "reference": "b0290636e88083acb42dba7b883aeaa16a60244f",
                 "shasum": ""
             },
             "require": {
@@ -208,7 +208,181 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2022-11-07T17:02:49+00:00"
+            "time": "2022-11-07T20:46:55+00:00"
+        },
+        {
+            "name": "laminas/laminas-form",
+            "version": "3.5.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-form.git",
+                "reference": "1563142cbf35972106e3404d4dd5cfdd48856b51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-form/zipball/1563142cbf35972106e3404d4dd5cfdd48856b51",
+                "reference": "1563142cbf35972106e3404d4dd5cfdd48856b51",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-hydrator": "^4.3.1",
+                "laminas/laminas-inputfilter": "^2.19.1",
+                "laminas/laminas-stdlib": "^3.7.1",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.12.0",
+                "laminas/laminas-captcha": "<2.13.0",
+                "laminas/laminas-eventmanager": "<3.6.0",
+                "laminas/laminas-i18n": "<2.19.0",
+                "laminas/laminas-recaptcha": "<3.4.0",
+                "laminas/laminas-servicemanager": "<3.19.0",
+                "laminas/laminas-view": "<2.24.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.13.3",
+                "ext-intl": "*",
+                "laminas/laminas-captcha": "^2.13",
+                "laminas/laminas-coding-standard": "^2.4",
+                "laminas/laminas-db": "^2.15",
+                "laminas/laminas-escaper": "^2.12",
+                "laminas/laminas-eventmanager": "^3.6",
+                "laminas/laminas-filter": "^2.23",
+                "laminas/laminas-i18n": "^2.19",
+                "laminas/laminas-modulemanager": "^2.12",
+                "laminas/laminas-recaptcha": "^3.4.0",
+                "laminas/laminas-servicemanager": "^3.19",
+                "laminas/laminas-session": "^2.13",
+                "laminas/laminas-text": "^2.9.0",
+                "laminas/laminas-validator": "^2.26",
+                "laminas/laminas-view": "^2.24",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.29"
+            },
+            "suggest": {
+                "doctrine/annotations": "^1.12, required to use laminas-form annotations support",
+                "laminas/laminas-captcha": "^2.11, required for using CAPTCHA form elements",
+                "laminas/laminas-eventmanager": "^3.4, reuired for laminas-form annotations support",
+                "laminas/laminas-i18n": "^2.12, required when using laminas-form view helpers",
+                "laminas/laminas-recaptcha": "^3.4, in order to use the ReCaptcha form element",
+                "laminas/laminas-servicemanager": "^3.10, required to use the form factories or provide services",
+                "laminas/laminas-view": "^2.14, required for using the laminas-form view helpers"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Form",
+                    "config-provider": "Laminas\\Form\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Form\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validate and display simple and complex forms, casting forms to business objects and vice versa",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "form",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-form/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-form/issues",
+                "rss": "https://github.com/laminas/laminas-form/releases.atom",
+                "source": "https://github.com/laminas/laminas-form"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-10-29T12:30:17+00:00"
+        },
+        {
+            "name": "laminas/laminas-hydrator",
+            "version": "4.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-hydrator.git",
+                "reference": "eae638f4912769b7336daf32fccb03c89e243ed6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-hydrator/zipball/eae638f4912769b7336daf32fccb03c89e243ed6",
+                "reference": "eae638f4912769b7336daf32fccb03c89e243ed6",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.3",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
+                "webmozart/assert": "^1.10"
+            },
+            "conflict": {
+                "laminas/laminas-servicemanager": "<3.14.0",
+                "zendframework/zend-hydrator": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "laminas/laminas-eventmanager": "^3.6",
+                "laminas/laminas-modulemanager": "^2.12",
+                "laminas/laminas-serializer": "^2.13.0",
+                "laminas/laminas-servicemanager": "^3.19",
+                "phpbench/phpbench": "^1.2.6",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "vimeo/psalm": "^4.29"
+            },
+            "suggest": {
+                "laminas/laminas-eventmanager": "^3.2, to support aggregate hydrator usage",
+                "laminas/laminas-serializer": "^2.9, to use the SerializableStrategy",
+                "laminas/laminas-servicemanager": "^3.14, to support hydrator plugin manager usage"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Hydrator",
+                    "config-provider": "Laminas\\Hydrator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Hydrator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Serialize objects to arrays, and vice versa",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "hydrator",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-hydrator/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-hydrator/issues",
+                "rss": "https://github.com/laminas/laminas-hydrator/releases.atom",
+                "source": "https://github.com/laminas/laminas-hydrator"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-10-24T15:56:12+00:00"
         },
         {
             "name": "laminas/laminas-i18n",
@@ -295,6 +469,80 @@
                 }
             ],
             "time": "2022-10-10T15:48:56+00:00"
+        },
+        {
+            "name": "laminas/laminas-inputfilter",
+            "version": "2.22.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-inputfilter.git",
+                "reference": "ec8b923d2c6923c24e4822a9ac77b4cd0f047ad3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-inputfilter/zipball/ec8b923d2c6923c24e4822a9ac77b4cd0f047ad3",
+                "reference": "ec8b923d2c6923c24e4822a9ac77b4cd0f047ad3",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-filter": "^2.13",
+                "laminas/laminas-servicemanager": "^3.16.0",
+                "laminas/laminas-stdlib": "^3.0",
+                "laminas/laminas-validator": "^2.15",
+                "php": "~8.0.0 || ~8.1.0 || ~8.2.0"
+            },
+            "conflict": {
+                "zendframework/zend-inputfilter": "*"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "laminas/laminas-coding-standard": "~2.4.0",
+                "phpunit/phpunit": "^9.5.25",
+                "psalm/plugin-phpunit": "^0.17.0",
+                "psr/http-message": "^1.0.1",
+                "vimeo/psalm": "^4.28",
+                "webmozart/assert": "^1.11"
+            },
+            "suggest": {
+                "psr/http-message-implementation": "PSR-7 is required if you wish to validate PSR-7 UploadedFileInterface payloads"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\InputFilter",
+                    "config-provider": "Laminas\\InputFilter\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\InputFilter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Normalize and validate input sets from the web, APIs, the CLI, and more, including files",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "inputfilter",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-inputfilter/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-inputfilter/issues",
+                "rss": "https://github.com/laminas/laminas-inputfilter/releases.atom",
+                "source": "https://github.com/laminas/laminas-inputfilter"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2022-11-04T13:12:58+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -660,6 +908,64 @@
                 }
             ],
             "time": "2022-05-24T11:49:31+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5.13"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
+            },
+            "time": "2022-06-03T18:03:27+00:00"
         }
     ],
     "packages-dev": [
@@ -4482,64 +4788,6 @@
                 }
             ],
             "time": "2022-02-15T19:52:12+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
-            },
-            "time": "2022-06-03T18:03:27+00:00"
         },
         {
             "name": "webmozart/path-util",

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,20 +13,6 @@
             <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
-
-    <issueHandlers>
-        <InternalMethod>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::method"/>
-            </errorLevel>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::willReturn"/>
-            </errorLevel>
-            <errorLevel type="suppress">
-                <referencedMethod name="PHPUnit\Framework\MockObject\Builder\InvocationMocker::with"/>
-            </errorLevel>
-        </InternalMethod>
-    </issueHandlers>
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>

--- a/psalm.xml
+++ b/psalm.xml
@@ -30,4 +30,7 @@
     <plugins>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
     </plugins>
+    <stubs>
+        <file name=".psr-container.php.stub"/>
+    </stubs>
 </psalm>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -38,6 +38,7 @@ final class ConfigProvider
             'filters'                   => $this->filterConfiguration(),
             'validators'                => $this->validatorConfiguration(),
             'view_helpers'              => $this->viewHelperConfiguration(),
+            'form_elements'             => $this->formElementConfiguration(),
         ];
     }
 
@@ -86,6 +87,18 @@ final class ConfigProvider
             ],
             'aliases'   => [
                 'phoneNumberFormat' => View\Helper\PhoneNumberFormat::class,
+            ],
+        ];
+    }
+
+    /**
+     * @return ServiceManagerConfigurationType
+     */
+    private function formElementConfiguration(): array
+    {
+        return [
+            'factories' => [
+                Form\Element\PhoneNumber::class => Form\Element\Factory\PhoneNumberFactory::class,
             ],
         ];
     }

--- a/src/Form/Element/Factory/PhoneNumberFactory.php
+++ b/src/Form/Element/Factory/PhoneNumberFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\PhoneNumber\Form\Element\Factory;
+
+use Laminas\I18n\PhoneNumber\Factory\Configuration;
+use Laminas\I18n\PhoneNumber\Form\Element\PhoneNumber;
+use Psr\Container\ContainerInterface;
+
+use function array_merge;
+
+/**
+ * @psalm-import-type Options from PhoneNumber
+ */
+final class PhoneNumberFactory
+{
+    /** @param Options|null $options */
+    public function __invoke(
+        ContainerInterface $container,
+        ?string $requestedName = null,
+        ?array $options = null
+    ): PhoneNumber {
+        $componentOptions = Configuration::componentConfig($container);
+
+        /** @psalm-var Options $resolvedOptions */
+        $resolvedOptions = array_merge([
+            'default_country' => $componentOptions['default-country-code'] ?? null,
+            'allowed_types'   => $componentOptions['acceptable-number-types'] ?? null,
+        ], $options ?? []);
+
+        return new PhoneNumber(null, $resolvedOptions);
+    }
+}

--- a/src/Form/Element/PhoneNumber.php
+++ b/src/Form/Element/PhoneNumber.php
@@ -7,7 +7,7 @@ namespace Laminas\I18n\PhoneNumber\Form\Element;
 use Laminas\Form\Element;
 use Laminas\I18n\CountryCode;
 use Laminas\I18n\PhoneNumber\PhoneNumberValue;
-use Laminas\I18n\PhoneNumber\Validator\PhoneNumber as NumberValidator;
+use Laminas\I18n\PhoneNumber\Validator\PhoneNumber as PhoneNumberValidator;
 use Laminas\InputFilter\InputFilterInterface;
 use Laminas\InputFilter\InputProviderInterface;
 use Laminas\Stdlib\ArrayUtils;
@@ -98,7 +98,7 @@ final class PhoneNumber extends Element implements InputProviderInterface
             'required'   => true,
             'validators' => [
                 [
-                    'name'    => NumberValidator::class,
+                    'name'    => PhoneNumberValidator::class,
                     'options' => [
                         'country_context' => $this->countryContext,
                         'country'         => $this->defaultCountry?->toString(),

--- a/src/Form/Element/PhoneNumber.php
+++ b/src/Form/Element/PhoneNumber.php
@@ -102,7 +102,7 @@ final class PhoneNumber extends Element implements InputProviderInterface
                     'options' => [
                         'country_context' => $this->countryContext,
                         'country'         => $this->defaultCountry?->toString(),
-                        'allowed_type'    => $this->allowedTypes,
+                        'allowed_types'   => $this->allowedTypes,
                     ],
                 ],
             ],

--- a/src/Form/Element/PhoneNumber.php
+++ b/src/Form/Element/PhoneNumber.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\PhoneNumber\Form\Element;
+
+use Laminas\Form\Element;
+use Laminas\I18n\CountryCode;
+use Laminas\I18n\PhoneNumber\PhoneNumberValue;
+use Laminas\I18n\PhoneNumber\Validator\PhoneNumber as NumberValidator;
+use Laminas\InputFilter\InputFilterInterface;
+use Laminas\InputFilter\InputProviderInterface;
+use Laminas\Stdlib\ArrayUtils;
+use Traversable;
+
+use function is_int;
+use function is_string;
+
+/**
+ * @psalm-import-type InputSpecification from InputFilterInterface
+ * @psalm-type Options = array{
+ *     country_context?: non-empty-string|null,
+ *     default_country?: non-empty-string|null,
+ *     allowed_types?: int-mask-of<PhoneNumberValue::TYPE_*>|null
+ * }&array<string, mixed>
+ */
+final class PhoneNumber extends Element implements InputProviderInterface
+{
+    /** @inheritDoc */
+    protected $attributes = [
+        'type' => 'text',
+    ];
+
+    /**
+     * The default country is passed to the phone number validator so that input in national format can be accepted
+     */
+    private ?CountryCode $defaultCountry = null;
+
+    /**
+     * The name of a form element used to retrieve a user-supplied country code from during validation
+     */
+    private ?string $countryContext = null;
+
+    /**
+     * A bit mask of allowable types of number
+     *
+     * @see PhoneNumberValue::TYPE_*
+     *
+     * @var int-mask-of<PhoneNumberValue::TYPE_*>|null
+     */
+    private ?int $allowedTypes = null;
+
+    /**
+     * @param Options|iterable $options
+     * @return $this
+     */
+    public function setOptions(iterable $options): self
+    {
+        if ($options instanceof Traversable) {
+            $options = ArrayUtils::iteratorToArray($options);
+        }
+
+        if (
+            isset($options['country_context'])
+            && is_string($options['country_context'])
+            && $options['country_context'] !== ''
+        ) {
+            $this->setCountryContext($options['country_context']);
+        }
+
+        if (
+            isset($options['default_country'])
+            && is_string($options['default_country'])
+            && $options['default_country'] !== ''
+        ) {
+            $this->setDefaultCountry($options['default_country']);
+        }
+
+        if (
+            isset($options['allowed_types'])
+            && is_int($options['allowed_types'])
+        ) {
+            $this->setAllowedTypes($options['allowed_types']);
+        }
+
+        unset($options['country_context'], $options['default_country'], $options['allowed_types']);
+
+        parent::setOptions($options);
+
+        return $this;
+    }
+
+    /** @return InputSpecification */
+    public function getInputSpecification(): array
+    {
+        return [
+            'name'       => (string) $this->getName(),
+            'required'   => true,
+            'validators' => [
+                [
+                    'name'    => NumberValidator::class,
+                    'options' => [
+                        'country_context' => $this->countryContext,
+                        'country'         => $this->defaultCountry?->toString(),
+                        'allowed_type'    => $this->allowedTypes,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /** @param non-empty-string $inputName */
+    public function setCountryContext(string $inputName): void
+    {
+        $this->countryContext = $inputName;
+    }
+
+    /** @param non-empty-string $code */
+    public function setDefaultCountry(string $code): void
+    {
+        $this->defaultCountry = CountryCode::fromString($code);
+    }
+
+    /** @param int-mask-of<PhoneNumberValue::TYPE_*> $types */
+    public function setAllowedTypes(int $types): void
+    {
+        $this->allowedTypes = $types;
+    }
+}

--- a/src/Validator/PhoneNumber.php
+++ b/src/Validator/PhoneNumber.php
@@ -24,7 +24,7 @@ use function sprintf;
  * @psalm-type Options = array{
  *     country?: non-empty-string|null,
  *     country_context?: non-empty-string|null,
- *     allowed_types?: int|null,
+ *     allowed_types?: int-mask-of<PhoneNumberValue::TYPE_*>|null,
  * }
  */
 final class PhoneNumber extends AbstractValidator
@@ -54,6 +54,8 @@ final class PhoneNumber extends AbstractValidator
      * Validate for specific types of phone number
      *
      * Restrict otherwise valid types of phone numbers to a subset of allowed types.
+     *
+     * @var int-mask-of<PhoneNumberValue::TYPE_*>
      */
     private int $allowTypes = PhoneNumberValue::TYPE_ANY;
 
@@ -169,6 +171,7 @@ final class PhoneNumber extends AbstractValidator
         $this->countryContext = $inputName;
     }
 
+    /** @param int-mask-of<PhoneNumberValue::TYPE_*> $types */
     public function setAllowedTypes(int $types): void
     {
         if ($types <= 0 || ($types & PhoneNumberValue::TYPE_KNOWN) !== $types) {

--- a/test/Form/FormIntegrationTest.php
+++ b/test/Form/FormIntegrationTest.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\PhoneNumber\Test\Form;
+
+use Laminas\Form\Element\Text;
+use Laminas\Form\Form;
+use Laminas\Form\FormElementManager;
+use Laminas\I18n\PhoneNumber\Form\Element\PhoneNumber;
+use Laminas\I18n\PhoneNumber\PhoneNumberValue;
+use Laminas\I18n\PhoneNumber\Test\NumberGeneratorTrait;
+use Laminas\I18n\PhoneNumber\Test\ProjectIntegrationTestCase;
+use Psr\Container\ContainerInterface;
+
+use function assert;
+
+final class FormIntegrationTest extends ProjectIntegrationTestCase
+{
+    use NumberGeneratorTrait;
+
+    private ContainerInterface $container;
+    private Form $form;
+    private FormElementManager $formElements;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->container = self::getContainer();
+
+        $formElements = $this->container->get(FormElementManager::class);
+        /** @psalm-suppress RedundantCondition */
+        assert($formElements instanceof FormElementManager);
+        $form = $formElements->get(Form::class);
+        assert($form instanceof Form);
+        $this->form         = $form;
+        $this->formElements = $formElements;
+    }
+
+    public function testThePhoneNumberElementCanBeRetrievedFromTheFormElementManager(): void
+    {
+        self::assertInstanceOf(PhoneNumber::class, $this->formElements->get(PhoneNumber::class));
+    }
+
+    /** @dataProvider validPhoneNumberProvider */
+    public function testThatGivenACountryContextThePhoneNumberHasTheExpectedValue(
+        string $number,
+        string $country,
+        int $type,
+    ): void {
+        if (($type & PhoneNumberValue::TYPE_RECOMMENDED) === 0) {
+            return;
+        }
+
+        $this->form->add([
+            'name' => 'country',
+            'type' => Text::class,
+        ]);
+        $this->form->add([
+            'name'    => 'number',
+            'type'    => PhoneNumber::class,
+            'options' => [
+                'country_context' => 'country',
+                'default_country' => null,
+            ],
+        ]);
+
+        $this->form->setData([
+            'country' => $country,
+            'number'  => $number,
+        ]);
+
+        self::assertTrue($this->form->isValid());
+        self::assertEquals([
+            'country' => $country,
+            'number'  => $number,
+        ], $this->form->getData());
+    }
+
+    /** @return list<array{0: string}> */
+    public function validE164Provider(): array
+    {
+        return [
+            ['+44 (0) 1234 567 890'],
+            ['+44 1234 567 890'],
+            ['+441234567890'],
+        ];
+    }
+
+    /** @dataProvider validE164Provider */
+    public function testThatAValidE164WithNoOtherContextIsConsideredValid(string $input): void
+    {
+        $this->form->add([
+            'name'    => 'number',
+            'type'    => PhoneNumber::class,
+            'options' => [
+                'country_context' => null,
+                'default_country' => null,
+            ],
+        ]);
+
+        $this->form->setData([
+            'number' => $input,
+        ]);
+
+        self::assertTrue($this->form->isValid());
+        self::assertEquals([
+            'number' => $input,
+        ], $this->form->getData());
+    }
+
+    /** @dataProvider validPhoneNumberProvider */
+    public function testThatTheCountryContextTakesPrecedenceOverTheDefaultCountry(
+        string $number,
+        string $country,
+        int $type,
+    ): void {
+        if (($type & PhoneNumberValue::TYPE_RECOMMENDED) === 0) {
+            return;
+        }
+
+        $this->form->add([
+            'name' => 'country',
+            'type' => Text::class,
+        ]);
+        $this->form->add([
+            'name'    => 'number',
+            'type'    => PhoneNumber::class,
+            'options' => [
+                'country_context' => 'country',
+                'default_country' => 'US',
+            ],
+        ]);
+
+        $this->form->setData([
+            'country' => $country,
+            'number'  => $number,
+        ]);
+
+        self::assertTrue($this->form->isValid());
+        self::assertEquals([
+            'country' => $country,
+            'number'  => $number,
+        ], $this->form->getData());
+    }
+
+    public function testThatTheDefaultCountryIsUsedWhenTheContextHasNoValue(): void
+    {
+        $this->form->add([
+            'name' => 'country',
+            'type' => Text::class,
+        ]);
+        $this->form->add([
+            'name'    => 'number',
+            'type'    => PhoneNumber::class,
+            'options' => [
+                'country_context' => 'country',
+                'default_country' => 'GB',
+            ],
+        ]);
+
+        $this->form->setData([
+            'country' => '',
+            'number'  => '01234 567 890',
+        ]);
+
+        self::assertTrue($this->form->isValid());
+        self::assertEquals([
+            'country' => '',
+            'number'  => '01234 567 890',
+        ], $this->form->getData());
+    }
+
+    public function testPhoneNumberValidityWithoutContextAndMismatchingDefaultCountry(): void
+    {
+        $this->form->add([
+            'name' => 'country',
+            'type' => Text::class,
+        ]);
+        $this->form->add([
+            'name'    => 'number',
+            'type'    => PhoneNumber::class,
+            'options' => [
+                'country_context' => 'country',
+                'default_country' => 'US',
+            ],
+        ]);
+
+        $this->form->setData([
+            'country' => '',
+            'number'  => '01234 567 890',
+        ]);
+
+        self::assertFalse($this->form->isValid());
+        $messages = $this->form->getMessages();
+        self::assertArrayHasKey('number', $messages);
+    }
+
+    public function testThatNoElementOptionsAreRequiredForValidationAgainstADefaultCountry(): void
+    {
+        $container = self::getContainer([
+            'laminas-i18n-phone-number' => [
+                'default-country-code' => 'SE',
+            ],
+        ]);
+
+        $form = $container->get(FormElementManager::class)->get(Form::class);
+        self::assertInstanceOf(Form::class, $form);
+
+        $form->add([
+            'name' => 'number',
+            'type' => PhoneNumber::class,
+        ]);
+        $form->setData(['number' => '031-3900600']);
+        self::assertTrue($form->isValid());
+    }
+}

--- a/test/Form/FormIntegrationTest.php
+++ b/test/Form/FormIntegrationTest.php
@@ -215,4 +215,25 @@ final class FormIntegrationTest extends ProjectIntegrationTestCase
         $form->setData(['number' => '031-3900600']);
         self::assertTrue($form->isValid());
     }
+
+    public function testAllowableTypesAsAConstructorOptionCanBeUsedToLimitValidNumberTypes(): void
+    {
+        $element = $this->formElements->build(
+            PhoneNumber::class,
+            [
+                'allowed_types'   => PhoneNumberValue::TYPE_EMERGENCY,
+                'default_country' => 'GB',
+            ],
+        );
+
+        $form = $this->formElements->get(Form::class);
+        assert($form instanceof Form);
+        $form->add($element, ['name' => 'num']);
+
+        $form->setData(['num' => '999']);
+        self::assertTrue($form->isValid());
+
+        $form->setData(['num' => '911']);
+        self::assertFalse($form->isValid());
+    }
 }

--- a/test/ProjectIntegrationTestCase.php
+++ b/test/ProjectIntegrationTestCase.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\I18n\PhoneNumber\Test;
+
+use Laminas;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+/**
+ * @psalm-import-type ServiceManagerConfigurationType from Laminas\ServiceManager\ConfigInterface
+ * @phpcs:disable WebimpressCodingStandard.NamingConventions.AbstractClass.Prefix
+ */
+abstract class ProjectIntegrationTestCase extends TestCase
+{
+    private const CONFIG_PROVIDERS = [
+        Laminas\Filter\ConfigProvider::class,
+        Laminas\Form\ConfigProvider::class,
+        Laminas\I18n\ConfigProvider::class,
+        Laminas\I18n\PhoneNumber\ConfigProvider::class,
+        Laminas\InputFilter\ConfigProvider::class,
+        Laminas\Validator\ConfigProvider::class,
+    ];
+
+    protected static function getContainer(array $userConfig = []): ContainerInterface
+    {
+        $providers   = self::CONFIG_PROVIDERS;
+        $providers[] = new Laminas\ConfigAggregator\ArrayProvider($userConfig);
+
+        $aggregator   = new Laminas\ConfigAggregator\ConfigAggregator($providers);
+        $config       = $aggregator->getMergedConfig();
+        $dependencies = $config['dependencies'] ?? [];
+        self::assertIsArray($dependencies);
+        /** @psalm-var ServiceManagerConfigurationType $dependencies */
+        $dependencies['services']['config'] = $config;
+
+        return new Laminas\ServiceManager\ServiceManager($dependencies);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

Adds a phone number form input that automatically attaches a phone number validator.

The input is factory backed so it is configured to use the package-wide setting for default country code and allowable types of number.

Settings can be modified during factory creation in the usual way.

Closes #2
