### PR TITLE
PHPUnit: Convert deprecations to exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /laminas-mkdoc-theme.tgz
 /laminas-mkdoc-theme/
 /vendor/
+/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0",
         "ext-intl": "*",
-        "giggsey/libphonenumber-for-php": "^8.13",
+        "giggsey/libphonenumber-for-php": "^8.13.1",
         "laminas/laminas-filter": "^2.27",
         "laminas/laminas-form": "^3.5",
         "laminas/laminas-i18n": "^2.19",
@@ -47,7 +47,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.4.0",
-        "laminas/laminas-config-aggregator": "^1.11",
+        "laminas/laminas-config-aggregator": "^1.12",
         "laminas/laminas-servicemanager": "^3.19",
         "maglnet/composer-require-checker": "^4.2",
         "phpunit/phpunit": "^9.5.26",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "23b5e5e2ccca4c6a7e7d88e055648b29",
+    "content-hash": "03ad2f7a1b2dba017daad6b14bf47077",
     "packages": [
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "8.13.0",
+            "version": "8.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "eb1cea72dc8d020e149062371a2c6717457cf561"
+                "reference": "58285eaba7cb388f57b5b1b3689a566694b4e043"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/eb1cea72dc8d020e149062371a2c6717457cf561",
-                "reference": "eb1cea72dc8d020e149062371a2c6717457cf561",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/58285eaba7cb388f57b5b1b3689a566694b4e043",
+                "reference": "58285eaba7cb388f57b5b1b3689a566694b4e043",
                 "shasum": ""
             },
             "require": {
@@ -76,7 +76,7 @@
                 "issues": "https://github.com/giggsey/libphonenumber-for-php/issues",
                 "source": "https://github.com/giggsey/libphonenumber-for-php"
             },
-            "time": "2022-11-07T12:16:34+00:00"
+            "time": "2022-11-28T12:02:06+00:00"
         },
         {
             "name": "giggsey/locale",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="vendor/autoload.php"
+    convertDeprecationsToExceptions="true"
     colors="true">
     <coverage processUncoveredFiles="true">
         <include>


### PR DESCRIPTION
Closes #13 

This should see tests fail across the board.

Requires a release of giggsey/libphonenumber