### PR TITLE
Override setOptions() to avoid crashes due to empty options.

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-The baseline is empty because there's 100% type coverage. The empty file persists so that it can be tracked
-over time in VCS in case future coverage drops with a compelling reason to baseline an issue.
--->
-<files psalm-version="4.21.0@d8bec4c7aaee111a532daec32fb09de5687053d1"/>
+<files psalm-version="4.30.0@d0bc6e25d89f649e4f36a534f330f8bb4643dd69">
+  <file src="src/Validator/PhoneNumber.php">
+    <PossiblyInvalidArgument occurrences="1">
+      <code>$options</code>
+    </PossiblyInvalidArgument>
+  </file>
+</files>

--- a/src/Validator/PhoneNumber.php
+++ b/src/Validator/PhoneNumber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\I18n\PhoneNumber\Validator;
 
+use Laminas\Form\Annotation\Options;
 use Laminas\I18n\CountryCode;
 use Laminas\I18n\PhoneNumber\Exception\InvalidOptionException;
 use Laminas\I18n\PhoneNumber\Exception\InvalidPhoneNumberExceptionInterface;
@@ -25,7 +26,7 @@ use function sprintf;
  *     country?: non-empty-string|null,
  *     country_context?: non-empty-string|null,
  *     allowed_types?: int-mask-of<PhoneNumberValue::TYPE_*>|null,
- * }
+ * }&array<string, mixed>
  */
 final class PhoneNumber extends AbstractValidator
 {
@@ -70,17 +71,20 @@ final class PhoneNumber extends AbstractValidator
      */
     private ?string $countryContext = null;
 
-    /** @param Options|Traversable<string, mixed>|null $options */
+    /** @param Options|iterable<string, mixed>|null $options */
     public function __construct($options = null)
+    {
+        parent::__construct($options);
+    }
+
+    /**
+     * @param Options|iterable<string, mixed> $options
+     * @return $this
+     */
+    public function setOptions($options = []): self
     {
         if ($options instanceof Traversable) {
             $options = ArrayUtils::iteratorToArray($options);
-        }
-
-        if (! is_array($options)) {
-            parent::__construct();
-
-            return;
         }
 
         if (isset($options['country']) && is_string($options['country']) && $options['country'] !== '') {
@@ -99,9 +103,11 @@ final class PhoneNumber extends AbstractValidator
             $this->setAllowedTypes($options['allowed_types']);
         }
 
-        unset($options['country'], $options['allowed_types']);
+        unset($options['country'], $options['country_context'], $options['allowed_types']);
 
-        parent::__construct($options);
+        parent::setOptions($options);
+
+        return $this;
     }
 
     /**

--- a/test/Validator/PhoneNumberTest.php
+++ b/test/Validator/PhoneNumberTest.php
@@ -238,4 +238,31 @@ class PhoneNumberTest extends TestCase
         ]);
         self::assertTrue($validator->isValid($input, $context));
     }
+
+    public function testRuntimeSetOptionsWithEmptyValuesDoNotCauseTypeErrors(): void
+    {
+        $validator = new PhoneNumber();
+        $validator->setOptions([
+            'country'         => null,
+            'allowed_types'   => null,
+            'country_context' => null,
+        ]);
+        self::assertTrue($validator->isValid('+441234567890'));
+    }
+
+    public function testRuntimeSetOptionsAreApplied(): void
+    {
+        $validator = new PhoneNumber([
+            'allowed_types' => PhoneNumberValue::TYPE_MOBILE,
+            'country'       => 'GB',
+        ]);
+
+        self::assertFalse($validator->isValid('999'));
+
+        $validator->setOptions([
+            'allowed_types' => PhoneNumberValue::TYPE_EMERGENCY,
+        ]);
+
+        self::assertTrue($validator->isValid('999'));
+    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

The options array was assessed for null/empty values in the constructor, but failed to account for `AbstractValidator::setOptions()` at runtime.

Fixes the inconvenience by moving constructor work to `setOptions`.