### PR TITLE
Updates the inclusion of snippets to use the full URL

### DIFF
--- a/docs/book/element/phone-number.md
+++ b/docs/book/element/phone-number.md
@@ -2,7 +2,7 @@
 
 `Laminas\I18n\PhoneNumber\Form\Element\PhoneNumber` is a text input form element that automatically attaches a PhoneNumber validator.
 
---8<-- "installation-requirements.md"
+--8<-- "https://raw.githubusercontent.com/laminas/laminas-i18n-phone-number/1.0.x/docs/snippets/installation-requirements.md"
 
 ## Basic Usage
 

--- a/docs/book/filters/to-e164.md
+++ b/docs/book/filters/to-e164.md
@@ -2,7 +2,7 @@
 
 The `ToE164` filter can be used to format phone numbers to [E.164 format](https://en.wikipedia.org/wiki/E.164).
 
---8<-- "installation-requirements.md"
+--8<-- "https://raw.githubusercontent.com/laminas/laminas-i18n-phone-number/1.0.x/docs/snippets/installation-requirements.md"
 
 ## Basic Usage
 

--- a/docs/book/filters/to-international-phone-number.md
+++ b/docs/book/filters/to-international-phone-number.md
@@ -2,7 +2,7 @@
 
 The `ToInternationalPhoneNumber` filter can be used to format phone numbers to the international format expected by the region the phone number belongs to.
 
---8<-- "installation-requirements.md"
+--8<-- "https://raw.githubusercontent.com/laminas/laminas-i18n-phone-number/1.0.x/docs/snippets/installation-requirements.md"
 
 ## Basic Usage
 

--- a/docs/book/filters/to-national-phone-number.md
+++ b/docs/book/filters/to-national-phone-number.md
@@ -2,7 +2,7 @@
 
 The `ToNationalPhoneNumber` filter can be used to format phone numbers to the national format expected by the region the phone number belongs to.  
 
---8<-- "installation-requirements.md"
+--8<-- "https://raw.githubusercontent.com/laminas/laminas-i18n-phone-number/1.0.x/docs/snippets/installation-requirements.md"
 
 ## Basic Usage
 

--- a/docs/book/helper/phone-number-format.md
+++ b/docs/book/helper/phone-number-format.md
@@ -2,7 +2,7 @@
 
 The `Laminas\I18n\PhoneNumber\View\Helper\PhoneNumberFormat` view helper provides a convenient way of formatting phone numbers in projects that make use of [`laminas/laminas-view`](https://docs.laminas.dev/laminas-view/).
 
---8<-- "installation-requirements.md"
+--8<-- "https://raw.githubusercontent.com/laminas/laminas-i18n-phone-number/1.0.x/docs/snippets/installation-requirements.md"
 
 ## Basic Usage
 

--- a/docs/book/validators/phone-number.md
+++ b/docs/book/validators/phone-number.md
@@ -3,7 +3,7 @@
 `Laminas\I18n\PhoneNumber\Validator\PhoneNumber` allows you to determine if a given value **is a valid phone number**.
 Phone number formats are country specific.
 
---8<-- "installation-requirements.md"
+--8<-- "https://raw.githubusercontent.com/laminas/laminas-i18n-phone-number/1.0.x/docs/snippets/installation-requirements.md"
 
 ## Basic Usage
 


### PR DESCRIPTION
This is only a _ugly_ and **temporary** workaround. The correct solution is still in progress: https://github.com/jdoiro3/mkdocs-multirepo-plugin/issues/11