### PR TITLE
Ensure `invalidPhoneNumberProvider` does not yield valid numbers

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "8.13.39",
+            "version": "8.13.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "5a36692616dba1ec4a24217f248021b1ec9cdade"
+                "reference": "795e0b760e5c439b6fa1ffa787c1d90c2face1ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/5a36692616dba1ec4a24217f248021b1ec9cdade",
-                "reference": "5a36692616dba1ec4a24217f248021b1ec9cdade",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/795e0b760e5c439b6fa1ffa787c1d90c2face1ff",
+                "reference": "795e0b760e5c439b6fa1ffa787c1d90c2face1ff",
                 "shasum": ""
             },
             "require": {
@@ -79,7 +79,7 @@
                 "issues": "https://github.com/giggsey/libphonenumber-for-php/issues",
                 "source": "https://github.com/giggsey/libphonenumber-for-php"
             },
-            "time": "2024-06-14T12:43:12+00:00"
+            "time": "2024-07-01T11:38:07+00:00"
         },
         {
             "name": "giggsey/locale",

--- a/test/NumberGeneratorTrait.php
+++ b/test/NumberGeneratorTrait.php
@@ -98,7 +98,9 @@ trait NumberGeneratorTrait
      */
     public static function invalidPhoneNumberProvider(): Generator
     {
-        $util = PhoneNumberUtil::getInstance();
+        $util      = PhoneNumberUtil::getInstance();
+        $shortInfo = ShortNumberInfo::getInstance();
+
         /** @var list<non-empty-string> $regions */
         $regions = $util->getSupportedRegions();
         foreach ($regions as $country) {
@@ -106,6 +108,19 @@ trait NumberGeneratorTrait
             if (! $number) {
                 continue;
             }
+
+            if (
+                $util->isValidNumber($number)
+                ||
+                $util->isValidNumberForRegion($number, $country)
+                ||
+                $shortInfo->isValidShortNumber($number)
+                ||
+                $shortInfo->isValidShortNumberForRegion($number, $country)
+            ) {
+                continue;
+            }
+
             $national = $number->getNationalNumber();
             assert(is_string($national));
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

This patch prevents potentially valid short numbers from being tested by filtering them out.

Recent meta-data changes mean that previously invalid numbers are now possibly valid short numbers.
