### PR TITLE
Deprecate runtime mutation of validator options

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -216,16 +216,16 @@
         },
         {
             "name": "laminas/laminas-form",
-            "version": "3.19.2",
+            "version": "3.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-form.git",
-                "reference": "f2ae01f6574ff9ca5139232c168e80b557b2b2aa"
+                "reference": "a50af078506a46b7bf53a2d6cd30d36a221546b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-form/zipball/f2ae01f6574ff9ca5139232c168e80b557b2b2aa",
-                "reference": "f2ae01f6574ff9ca5139232c168e80b557b2b2aa",
+                "url": "https://api.github.com/repos/laminas/laminas-form/zipball/a50af078506a46b7bf53a2d6cd30d36a221546b3",
+                "reference": "a50af078506a46b7bf53a2d6cd30d36a221546b3",
                 "shasum": ""
             },
             "require": {
@@ -261,7 +261,7 @@
                 "laminas/laminas-validator": "^2.43",
                 "laminas/laminas-view": "^2.32",
                 "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
+                "psalm/plugin-phpunit": "^0.19.0",
                 "vimeo/psalm": "^5.16"
             },
             "suggest": {
@@ -309,7 +309,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-02-19T07:08:43+00:00"
+            "time": "2024-07-08T06:59:53+00:00"
         },
         {
             "name": "laminas/laminas-hydrator",
@@ -752,16 +752,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.60.0",
+            "version": "2.61.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "66ab091fc08a8b1e2851eec62dda4bafa977fe9c"
+                "reference": "df77732fbfab331647a5e718d171507269e73b6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/66ab091fc08a8b1e2851eec62dda4bafa977fe9c",
-                "reference": "66ab091fc08a8b1e2851eec62dda4bafa977fe9c",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/df77732fbfab331647a5e718d171507269e73b6c",
+                "reference": "df77732fbfab331647a5e718d171507269e73b6c",
                 "shasum": ""
             },
             "require": {
@@ -832,7 +832,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-06-25T20:11:22+00:00"
+            "time": "2024-07-11T21:26:44+00:00"
         },
         {
             "name": "psr/container",
@@ -1430,16 +1430,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
+                "reference": "8536c1b9103405bcbd310c69e7a5739a1c2b1f0b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
-                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "url": "https://api.github.com/repos/composer/semver/zipball/8536c1b9103405bcbd310c69e7a5739a1c2b1f0b",
+                "reference": "8536c1b9103405bcbd310c69e7a5739a1c2b1f0b",
                 "shasum": ""
             },
             "require": {
@@ -1491,7 +1491,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.0"
+                "source": "https://github.com/composer/semver/tree/3.4.1"
             },
             "funding": [
                 {
@@ -1507,7 +1507,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-31T09:50:34+00:00"
+            "time": "2024-07-12T09:13:09+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -2870,16 +2870,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.25",
+            "version": "10.5.27",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "831bf82312be6037e811833ddbea0b8de60ea314"
+                "reference": "2425f713b2a5350568ccb1a2d3984841a23e83c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/831bf82312be6037e811833ddbea0b8de60ea314",
-                "reference": "831bf82312be6037e811833ddbea0b8de60ea314",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2425f713b2a5350568ccb1a2d3984841a23e83c5",
+                "reference": "2425f713b2a5350568ccb1a2d3984841a23e83c5",
                 "shasum": ""
             },
             "require": {
@@ -2889,26 +2889,26 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
+                "myclabs/deep-copy": "^1.12.0",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.5",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-invoker": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "phpunit/php-timer": "^6.0",
-                "sebastian/cli-parser": "^2.0",
-                "sebastian/code-unit": "^2.0",
-                "sebastian/comparator": "^5.0",
-                "sebastian/diff": "^5.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/exporter": "^5.1",
-                "sebastian/global-state": "^6.0.1",
-                "sebastian/object-enumerator": "^5.0",
-                "sebastian/recursion-context": "^5.0",
-                "sebastian/type": "^4.0",
-                "sebastian/version": "^4.0"
+                "phpunit/php-code-coverage": "^10.1.15",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.1",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.2",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -2951,7 +2951,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.27"
             },
             "funding": [
                 {
@@ -2967,7 +2967,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T05:49:17+00:00"
+            "time": "2024-07-10T11:48:06+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",

--- a/docs/book/validators/phone-number.md
+++ b/docs/book/validators/phone-number.md
@@ -122,14 +122,17 @@ $options = [
 $validator = new PhoneNumber($options);
 ```
 
+## Runtime Modification of Options
+
+CAUTION: **Deprecated**
+Runtime mutation of options is deprecated and will be removed in version 2.0
+
 Options can also be changed at runtime with:
 
 ```php
 $validator = new Laminas\I18n\PhoneNumber\Validator\PhoneNumber();
 $validator->setOptions($options);
 ```
-
-## Runtime Modification of Options
 
 Each of the 3 options have companion "setters" to change the runtime behaviour of the validator after it has been constructed:
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,75 +1,87 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.8.0@9cf4f60a333f779ad3bc704a555920e81d4fdcda">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
   <file src="src/Filter/Factory/ToE164Factory.php">
     <UnusedParam>
-      <code>$name</code>
+      <code><![CDATA[$name]]></code>
     </UnusedParam>
   </file>
   <file src="src/Filter/Factory/ToInternationalPhoneNumberFactory.php">
     <UnusedParam>
-      <code>$name</code>
+      <code><![CDATA[$name]]></code>
     </UnusedParam>
   </file>
   <file src="src/Filter/Factory/ToNationalPhoneNumberFactory.php">
     <UnusedParam>
-      <code>$name</code>
+      <code><![CDATA[$name]]></code>
     </UnusedParam>
   </file>
   <file src="src/Form/Element/Factory/PhoneNumberFactory.php">
     <UnusedParam>
-      <code>$requestedName</code>
+      <code><![CDATA[$requestedName]]></code>
     </UnusedParam>
   </file>
   <file src="src/Module.php">
     <UnusedClass>
-      <code>Module</code>
+      <code><![CDATA[Module]]></code>
     </UnusedClass>
   </file>
   <file src="src/Validator/Factory/PhoneNumberFactory.php">
     <UnusedParam>
-      <code>$requestedName</code>
+      <code><![CDATA[$requestedName]]></code>
     </UnusedParam>
+  </file>
+  <file src="src/Validator/PhoneNumber.php">
+    <DeprecatedMethod>
+      <code><![CDATA[parent::setOptions($options)]]></code>
+      <code><![CDATA[setAllowedTypes]]></code>
+      <code><![CDATA[setCountry]]></code>
+      <code><![CDATA[setCountryContext]]></code>
+    </DeprecatedMethod>
   </file>
   <file src="test/Factory/ConfigurationTest.php">
     <PossiblyUnusedMethod>
-      <code>nullConfigProvider</code>
+      <code><![CDATA[nullConfigProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/Filter/AbstractFilterTest.php">
     <PossiblyUnusedMethod>
-      <code>filterClassProvider</code>
+      <code><![CDATA[filterClassProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/Filter/FilterPluginManagerIntegrationTest.php">
     <PossiblyUnusedMethod>
-      <code>filterClassProvider</code>
+      <code><![CDATA[filterClassProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/Form/FormIntegrationTest.php">
     <PossiblyUnusedMethod>
-      <code>validE164Provider</code>
+      <code><![CDATA[validE164Provider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/NumberGeneratorTrait.php">
     <PossiblyUnusedMethod>
-      <code>invalidPhoneNumberProvider</code>
-      <code>invalidPhoneNumberProvider</code>
-      <code>invalidPhoneNumberProvider</code>
-      <code>validPhoneNumberProvider</code>
-      <code>validPhoneNumberProvider</code>
-      <code>validPhoneNumberProvider</code>
+      <code><![CDATA[invalidPhoneNumberProvider]]></code>
+      <code><![CDATA[invalidPhoneNumberProvider]]></code>
+      <code><![CDATA[invalidPhoneNumberProvider]]></code>
+      <code><![CDATA[validPhoneNumberProvider]]></code>
+      <code><![CDATA[validPhoneNumberProvider]]></code>
+      <code><![CDATA[validPhoneNumberProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/PhoneNumberValueTest.php">
     <PossiblyUnusedMethod>
-      <code>internationalFormatsProvider</code>
+      <code><![CDATA[internationalFormatsProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/Validator/PhoneNumberTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setOptions]]></code>
+      <code><![CDATA[setOptions]]></code>
+    </DeprecatedMethod>
     <PossiblyUnusedMethod>
-      <code>invalidAllowedTypeProvider</code>
-      <code>invalidCountryProvider</code>
-      <code>invalidTypeProvider</code>
+      <code><![CDATA[invalidAllowedTypeProvider]]></code>
+      <code><![CDATA[invalidCountryProvider]]></code>
+      <code><![CDATA[invalidTypeProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
 </files>

--- a/src/Validator/PhoneNumber.php
+++ b/src/Validator/PhoneNumber.php
@@ -78,6 +78,8 @@ final class PhoneNumber extends AbstractValidator
     }
 
     /**
+     * @deprecated Since 1.2.0 Option setters will be removed in 2.0. Provide options to the constructor instead
+     *
      * @param Options|iterable<string, mixed> $options
      * @return $this
      */
@@ -156,7 +158,11 @@ final class PhoneNumber extends AbstractValidator
         return true;
     }
 
-    /** @param non-empty-string $countryCodeOrLocale */
+    /**
+     * @deprecated Since 1.2.0 Option setters will be removed in 2.0. Provide options to the constructor instead
+     *
+     * @param non-empty-string $countryCodeOrLocale
+     */
     public function setCountry(string $countryCodeOrLocale): void
     {
         $code = CountryCode::tryFromString($countryCodeOrLocale);
@@ -171,13 +177,21 @@ final class PhoneNumber extends AbstractValidator
         $this->country = $code;
     }
 
-    /** @param non-empty-string $inputName */
+    /**
+     * @deprecated Since 1.2.0 Option setters will be removed in 2.0. Provide options to the constructor instead
+     *
+     * @param non-empty-string $inputName
+     */
     public function setCountryContext(string $inputName): void
     {
         $this->countryContext = $inputName;
     }
 
-    /** @param int-mask-of<PhoneNumberValue::TYPE_*> $types */
+    /**
+     * @deprecated Since 1.2.0 Option setters will be removed in 2.0. Provide options to the constructor instead
+     *
+     * @param int-mask-of<PhoneNumberValue::TYPE_*> $types
+     */
     public function setAllowedTypes(int $types): void
     {
         if ($types <= 0 || ($types & PhoneNumberValue::TYPE_KNOWN) !== $types) {

--- a/test/Validator/PhoneNumberTest.php
+++ b/test/Validator/PhoneNumberTest.php
@@ -36,11 +36,8 @@ class PhoneNumberTest extends TestCase
         ];
     }
 
-    /**
-     * @param mixed $value
-     */
     #[DataProvider('invalidTypeProvider')]
-    public function testInvalidTypes($value): void
+    public function testInvalidTypes(mixed $value): void
     {
         $validator = new PhoneNumber();
         self::assertFalse($validator->isValid($value));
@@ -72,7 +69,7 @@ class PhoneNumberTest extends TestCase
     {
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('Country codes must be ISO 3166 2-letter codes');
-        (new PhoneNumber())->setCountry($option);
+        new PhoneNumber(['country' => $option]);
     }
 
     /** @return array<array-key, array{0: int}> */
@@ -92,7 +89,7 @@ class PhoneNumberTest extends TestCase
     {
         $this->expectException(InvalidOptionException::class);
         $this->expectExceptionMessage('The allowed types provided do not match known valid types');
-        (new PhoneNumber())->setAllowedTypes($option);
+        new PhoneNumber(['allowedTypes' => $option]);
     }
 
     public function testThatWhenTheCountryIsProvidedNationalPhoneNumbersAreValid(): void
@@ -127,8 +124,7 @@ class PhoneNumberTest extends TestCase
     #[DataProvider('invalidPhoneNumberProvider')]
     public function testThatInvalidNumbersAreConsideredInvalid(string $number, string $country): void
     {
-        $validator = new PhoneNumber();
-        $validator->setCountry($country);
+        $validator = new PhoneNumber(['country' => $country]);
 
         self::assertFalse($validator->isValid($number));
     }
@@ -140,8 +136,7 @@ class PhoneNumberTest extends TestCase
     #[DataProvider('validPhoneNumberProvider')]
     public function testThatValidNumbersAreConsideredValid(string $number, string $country): void
     {
-        $validator = new PhoneNumber();
-        $validator->setCountry($country);
+        $validator = new PhoneNumber(['country' => $country]);
 
         self::assertTrue($validator->isValid($number));
     }
@@ -159,12 +154,10 @@ class PhoneNumberTest extends TestCase
         $validator = new PhoneNumber();
         self::assertTrue($validator->isValid($possible), 'The number should be "normally" valid');
 
-        $validator = new PhoneNumber();
-        $validator->setAllowedTypes(PhoneNumberValue::TYPE_MOBILE);
+        $validator = new PhoneNumber(['allowedTypes' => PhoneNumberValue::TYPE_MOBILE]);
         self::assertTrue($validator->isValid($possible), 'The number should still be valid when allowed types are set');
 
-        $validator = new PhoneNumber();
-        $validator->setAllowedTypes(PhoneNumberValue::TYPE_FIXED);
+        $validator = new PhoneNumber(['allowedTypes' => PhoneNumberValue::TYPE_FIXED]);
         self::assertTrue($validator->isValid($possible), 'The number should still be valid when allowed types are set');
     }
 
@@ -195,12 +188,10 @@ class PhoneNumberTest extends TestCase
             }
         };
 
-        $validator = new PhoneNumber();
-        $validator->setCountry('GB');
+        $validator = new PhoneNumber(['country' => 'GB']);
         self::assertTrue($validator->isValid($object));
 
-        $validator = new PhoneNumber();
-        $validator->setCountry('US');
+        $validator = new PhoneNumber(['country' => 'US']);
         self::assertFalse($validator->isValid($object));
         $messages = $validator->getMessages();
         self::assertArrayHasKey(PhoneNumber::INVALID, $messages);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| QA            | yes

### Description

Deprecates:

- setOptions
- setCountry
- setCountryContext
- setAllowedTypes

In the phone number validator in line with deprecations in `laminas-validator@2.61.0`

Adjust tests to reduce usage of deprecated methods and expand baseline with unresolvable deprecations.