### PR TITLE
Upgrade `giggsey/libphonenumber-for-php` to v9.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "require": {
         "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-intl": "*",
-        "giggsey/libphonenumber-for-php": "^8.13.1",
+        "giggsey/libphonenumber-for-php": "^9.0.0",
         "laminas/laminas-filter": "^2.27",
         "laminas/laminas-form": "^3.5",
         "laminas/laminas-i18n": "^2.19",

--- a/composer.lock
+++ b/composer.lock
@@ -4,45 +4,50 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85f7e494ad3447c9e9b153a5ce9ec289",
+    "content-hash": "aa676a9e87f6852e1b9e71a8c72ef624",
     "packages": [
         {
             "name": "giggsey/libphonenumber-for-php",
-            "version": "8.13.55",
+            "version": "9.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/giggsey/libphonenumber-for-php.git",
-                "reference": "6e28b3d53cf96d7f41c83d9b80b6021ecbd00537"
+                "reference": "8dc024f0a9b0a0d19e0c0042cd0a6b16ce8eab0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/6e28b3d53cf96d7f41c83d9b80b6021ecbd00537",
-                "reference": "6e28b3d53cf96d7f41c83d9b80b6021ecbd00537",
+                "url": "https://api.github.com/repos/giggsey/libphonenumber-for-php/zipball/8dc024f0a9b0a0d19e0c0042cd0a6b16ce8eab0e",
+                "reference": "8dc024f0a9b0a0d19e0c0042cd0a6b16ce8eab0e",
                 "shasum": ""
             },
             "require": {
-                "giggsey/locale": "^2.0",
-                "php": "^7.4|^8.0",
-                "symfony/polyfill-mbstring": "^1.17"
+                "giggsey/locale": "^2.7",
+                "php": "^8.1",
+                "symfony/polyfill-mbstring": "^1.31"
             },
             "replace": {
                 "giggsey/libphonenumber-for-php-lite": "self.version"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.64",
-                "pear/pear-core-minimal": "^1.10",
-                "pear/pear_exception": "^1.0",
-                "pear/versioncontrol_git": "^0.7",
-                "phing/phing": "^3.0",
-                "php-coveralls/php-coveralls": "^2.0",
-                "phpunit/phpunit": "^9.6",
-                "symfony/console": "^v5.2",
-                "symfony/var-exporter": "^5.2"
+                "ext-dom": "*",
+                "friendsofphp/php-cs-fixer": "^3.71",
+                "infection/infection": "^0.28.0",
+                "nette/php-generator": "^4.1",
+                "php-coveralls/php-coveralls": "^2.7",
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.7",
+                "phpstan/phpstan-deprecation-rules": "^2.0.1",
+                "phpstan/phpstan-phpunit": "^2.0.4",
+                "phpstan/phpstan-strict-rules": "^2.0.3",
+                "phpunit/phpunit": "^10.5.45",
+                "symfony/console": "^6.4",
+                "symfony/filesystem": "^6.4",
+                "symfony/process": "^6.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "8.x-dev"
+                    "dev-master": "9.x-dev"
                 }
             },
             "autoload": {
@@ -67,7 +72,7 @@
                     "homepage": "https://giggsey.com/"
                 }
             ],
-            "description": "PHP Port of Google's libphonenumber",
+            "description": "A library for parsing, formatting, storing and validating international phone numbers, a PHP Port of Google's libphonenumber.",
             "homepage": "https://github.com/giggsey/libphonenumber-for-php",
             "keywords": [
                 "geocoding",
@@ -81,7 +86,7 @@
                 "issues": "https://github.com/giggsey/libphonenumber-for-php/issues",
                 "source": "https://github.com/giggsey/libphonenumber-for-php"
             },
-            "time": "2025-02-14T08:14:08+00:00"
+            "time": "2025-03-19T16:51:35+00:00"
         },
         {
             "name": "giggsey/locale",

--- a/src/PhoneNumberValue.php
+++ b/src/PhoneNumberValue.php
@@ -14,8 +14,6 @@ use libphonenumber\PhoneNumberType;
 use libphonenumber\PhoneNumberUtil;
 use libphonenumber\ShortNumberInfo;
 
-use function array_key_exists;
-
 final class PhoneNumberValue
 {
     public const TYPE_FIXED         = 1;
@@ -54,25 +52,6 @@ final class PhoneNumberValue
     public const TYPE_RECOMMENDED = self::TYPE_FIXED
                                   | self::TYPE_MOBILE
                                   | self::TYPE_VOIP;
-
-    /** @internal \Laminas\I18n */
-    public const TYPE_MAP = [
-        PhoneNumberType::FIXED_LINE           => self::TYPE_FIXED,
-        PhoneNumberType::MOBILE               => self::TYPE_MOBILE,
-        PhoneNumberType::FIXED_LINE_OR_MOBILE => self::TYPE_FIXED | self::TYPE_MOBILE,
-        PhoneNumberType::TOLL_FREE            => self::TYPE_TOLL_FREE,
-        PhoneNumberType::PREMIUM_RATE         => self::TYPE_PREMIUM_RATE,
-        PhoneNumberType::SHARED_COST          => self::TYPE_SHARED_COST,
-        PhoneNumberType::VOIP                 => self::TYPE_VOIP,
-        PhoneNumberType::PERSONAL_NUMBER      => self::TYPE_PERSONAL,
-        PhoneNumberType::PAGER                => self::TYPE_PAGER,
-        PhoneNumberType::UAN                  => self::TYPE_UAN,
-        PhoneNumberType::UNKNOWN              => self::TYPE_UNKNOWN,
-        PhoneNumberType::EMERGENCY            => self::TYPE_EMERGENCY,
-        PhoneNumberType::VOICEMAIL            => self::TYPE_VOICEMAIL,
-        PhoneNumberType::SHORT_CODE           => self::TYPE_SHORT_CODE,
-        PhoneNumberType::STANDARD_RATE        => self::TYPE_STANDARD_RATE,
-    ];
 
     /**
      * @param non-empty-string $regionCode The ISO 3166 Country Code associated with the number
@@ -176,11 +155,7 @@ final class PhoneNumberValue
             return self::TYPE_SHORT_CODE;
         }
 
-        if (! array_key_exists($type, self::TYPE_MAP)) {
-            return self::TYPE_UNKNOWN;
-        }
-
-        return self::TYPE_MAP[$type];
+        return self::mapType($type);
     }
 
     /**
@@ -201,5 +176,30 @@ final class PhoneNumberValue
             : $givenCode;
 
         return $regionCode !== '' ? $regionCode : null;
+    }
+
+    /**
+     * @psalm-internal Laminas\I18n
+     * @return self::TYPE_*
+     */
+    public static function mapType(PhoneNumberType $type): int
+    {
+        return match ($type) {
+            PhoneNumberType::FIXED_LINE           => self::TYPE_FIXED,
+            PhoneNumberType::MOBILE               => self::TYPE_MOBILE,
+            PhoneNumberType::FIXED_LINE_OR_MOBILE => self::TYPE_FIXED | self::TYPE_MOBILE,
+            PhoneNumberType::TOLL_FREE            => self::TYPE_TOLL_FREE,
+            PhoneNumberType::PREMIUM_RATE         => self::TYPE_PREMIUM_RATE,
+            PhoneNumberType::SHARED_COST          => self::TYPE_SHARED_COST,
+            PhoneNumberType::VOIP                 => self::TYPE_VOIP,
+            PhoneNumberType::PERSONAL_NUMBER      => self::TYPE_PERSONAL,
+            PhoneNumberType::PAGER                => self::TYPE_PAGER,
+            PhoneNumberType::UAN                  => self::TYPE_UAN,
+            PhoneNumberType::UNKNOWN              => self::TYPE_UNKNOWN,
+            PhoneNumberType::EMERGENCY            => self::TYPE_EMERGENCY,
+            PhoneNumberType::VOICEMAIL            => self::TYPE_VOICEMAIL,
+            PhoneNumberType::SHORT_CODE           => self::TYPE_SHORT_CODE,
+            PhoneNumberType::STANDARD_RATE        => self::TYPE_STANDARD_RATE,
+        };
     }
 }

--- a/test/NumberGeneratorTrait.php
+++ b/test/NumberGeneratorTrait.php
@@ -28,14 +28,13 @@ trait NumberGeneratorTrait
     {
         $util  = PhoneNumberUtil::getInstance();
         $short = ShortNumberInfo::getInstance();
-        /** @var list<int> $libTypes */
-        $libTypes = PhoneNumberType::values();
         /** @var list<non-empty-string> $regions */
         $regions = $util->getSupportedRegions();
         foreach ($regions as $country) {
-            /** @var int $type */
             foreach ($util->getSupportedTypesForRegion($country) as $type) {
-                $typeName = $libTypes[$type];
+                /** @psalm-suppress RedundantConditionGivenDocblockType This assertion is useful for inference in an IDE */
+                assert($type instanceof PhoneNumberType);
+                $typeName = $type->name;
                 $number   = $util->getExampleNumberForType($country, $type);
                 if (! $number) {
                     continue; // There might not be an example number for the given type and country
@@ -62,7 +61,7 @@ trait NumberGeneratorTrait
                 }
 
                 $label      = sprintf('Valid %s Example Number: %s (%s)', $country, $national, $typeName);
-                $expectType = PhoneNumberValue::TYPE_MAP[$type];
+                $expectType = PhoneNumberValue::mapType($type);
 
                 yield $label => [
                     $national,
@@ -81,7 +80,7 @@ trait NumberGeneratorTrait
                 'Valid %s Short Number: %s (%s)',
                 $country,
                 $inputNumber,
-                $libTypes[$type]
+                $type->name,
             );
 
             yield $label => [


### PR DESCRIPTION
The `PhoneNumberType` constants are now an enum in version 9, so an `@internal` constant that maps those types to internal types has been replaced with an `@internal` static method _(A constant cannot be used because PHP 8.1 does not support enum case expressions in constants)_

Closes #44 
